### PR TITLE
Remove shortcut in residue distance calculation

### DIFF
--- a/src/DockQ/operations.pyx
+++ b/src/DockQ/operations.pyx
@@ -27,10 +27,6 @@ def residue_distances(float [:,:] atom_coordinates1, float [:,:] atom_coordinate
                     this_d = (atom_coordinates1[x][0] - atom_coordinates2[y][0])**2 + (atom_coordinates1[x][1] - atom_coordinates2[y][1])**2 + (atom_coordinates1[x][2] - atom_coordinates2[y][2])**2
                     if this_d < min_d:
                         min_d = this_d
-                        if min_d > 400.0:
-                            break
-                if min_d > 400.0:
-                    break
             res_distances[i, j] = min_d
             cum_j_atoms = cum_j_atoms + j_atoms
         cum_i_atoms = cum_i_atoms + i_atoms


### PR DESCRIPTION
The distance matrix calculation currently uses a shortcut: If any atom distance exceeds 20 Å (400 Å^2), the distance calculation is aborted for that residue. I assume the rationale behind this is that, if any atom pair is this far away, there is no way that It may form a contact.

However there are such cases, where there is still a contact: An example is `2E31` at (chain A, Glu 230 <-> chain B, Arg 154). The actual minimum distance is 9.6 Å, while the DockQ calculation stops and returns 20.1 Å.

Hence, This PR proposes to remove shortcut as it may lead to false results in some cases.