### PR TITLE
Use aligned residues for contact computation

### DIFF
--- a/src/DockQ/DockQ.py
+++ b/src/DockQ/DockQ.py
@@ -319,7 +319,7 @@ def calc_DockQ(
 
     if capri_peptide:
         ref_res_distances = get_residue_distances(
-            ref_chains[0], ref_chains[1], "ref", all_atom=False
+            aligned_ref_1, aligned_ref_2, "ref", all_atom=False
         )
     # Get interfacial atoms from reference, and corresponding atoms from sample
     interacting_pairs = get_interacting_pairs(


### PR DESCRIPTION
I found a potential oversight, where instead of the aligned chains the original ones are used for distance computation. This may lead to shifted identification of contact residues as `get_interface_atoms()` then uses the distances computed for the original chains but the coordinates from the aligned chains.