### PR TITLE
Fix `run_on_all_native_interfaces` description in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ optional arguments:
 
 **Importing DockQ as python module**
 
-Once DockQ is installed with pip, it can also be used as a module in your python code:
+Once DockQ is installed with pip, it can also be used as a module in your python code (note that in this case the chain mapping has to be provided in the form native:model, not model:native):
 
 ```{python}
 from DockQ.DockQ import load_PDB, run_on_all_native_interfaces
@@ -220,7 +220,7 @@ from DockQ.DockQ import load_PDB, run_on_all_native_interfaces
 model = load_PDB("examples/1A2K_r_l_b.model.pdb")
 native = load_PDB("examples/1A2K_r_l_b.pdb")
 
-# model:native chain map dictionary for two interfaces
+# native:model chain map dictionary for two interfaces
 chain_map = {"A":"A", "B":"B"}
 # returns a dictionary containing the results and the total DockQ score
 run_on_all_native_interfaces(model, native, chain_map=chain_map)


### PR DESCRIPTION
The `run_all_native_interfaces` function [requires](https://github.com/bjornwallner/DockQ/blob/13c9dcc84ef2751ecf6b958c6f55dc1981457b16/src/DockQ/DockQ.py#L610) chain mappings to be of the form native:model instead of model:native as per the `--mapping` command-line argument.   This discrepancy is due to [`format_mapping`](https://github.com/bjornwallner/DockQ/blob/13c9dcc84ef2751ecf6b958c6f55dc1981457b16/src/DockQ/DockQ.py#L749) which performs the switch when using the CLI, but it is not correctly reflected in the README, and users should be warned clearly about it.